### PR TITLE
ScalaTest+JMock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.class
 *.log
+target/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,10 @@
 # jmock
 ScalaTest + JMock provides integration support between ScalaTest and JMock.
+
+**Publishing**
+
+Please use the following commands to publish to Sonatype: 
+
+```
+$ sbt +publishSigned
+```

--- a/build.sbt
+++ b/build.sbt
@@ -30,6 +30,28 @@ libraryDependencies ++= Seq(
   "org.scalatest" %% "scalatest" % "3.1.0-SNAP8"
 )
 
+enablePlugins(SbtOsgi)
+
+osgiSettings
+
+OsgiKeys.exportPackage := Seq(
+  "org.scalatestplus.jmock.*"
+)
+
+OsgiKeys.importPackage := Seq(
+  "org.scalatest.*",
+  "org.scalactic.*", 
+  "scala.*;version=\"$<range;[==,=+);$<replace;"+scalaBinaryVersion.value+";-;.>>\"",
+  "*;resolution:=optional"
+)
+
+OsgiKeys.additionalHeaders:= Map(
+  "Bundle-Name" -> "ScalaTestPlusJMock",
+  "Bundle-Description" -> "ScalaTest+JMock is an open-source integration library between ScalaTest and JMock for Scala projects.",
+  "Bundle-DocURL" -> "http://www.scalatest.org/",
+  "Bundle-Vendor" -> "Artima, Inc."
+)
+
 publishTo := {
   val nexus = "https://oss.sonatype.org/"
   Some("publish-releases" at nexus + "service/local/staging/deploy/maven2")

--- a/build.sbt
+++ b/build.sbt
@@ -1,0 +1,48 @@
+name := "scalatestplus-jmock"
+
+organization := "org.scalatestplus"
+
+version := "1.0.0-SNAP1"
+
+homepage := Some(url("https://github.com/scalatest/scalatestplus-jmock"))
+
+licenses := List("Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0"))
+
+developers := List(
+  Developer(
+    "bvenners",
+    "Bill Venners",
+    "bill@artima.com",
+    url("https://github.com/bvenners")
+  ),
+  Developer(
+    "cheeseng",
+    "Chua Chee Seng",
+    "cheeseng@amaseng.com",
+    url("https://github.com/cheeseng")
+  )
+)
+
+crossScalaVersions := List("2.11.12", "2.12.8", "2.13.0-M5")
+
+libraryDependencies ++= Seq(
+  "org.jmock" % "jmock-legacy" % "2.8.3",
+  "org.scalatest" %% "scalatest" % "3.1.0-SNAP7"
+)
+
+publishTo := {
+  val nexus = "https://oss.sonatype.org/"
+  Some("publish-releases" at nexus + "service/local/staging/deploy/maven2")
+}
+
+publishMavenStyle := true
+
+publishArtifact in Test := false
+
+pomIncludeRepository := { _ => false }
+
+credentials += Credentials(Path.userHome / ".ivy2" / ".credentials")
+
+pgpSecretRing := file((Path.userHome / ".gnupg" / "secring.gpg").getAbsolutePath)
+
+pgpPassphrase := None

--- a/build.sbt
+++ b/build.sbt
@@ -23,11 +23,11 @@ developers := List(
   )
 )
 
-crossScalaVersions := List("2.11.12", "2.12.8", "2.13.0-M5")
+crossScalaVersions := List("2.10.7", "2.11.12", "2.12.8", "2.13.0-M5")
 
 libraryDependencies ++= Seq(
   "org.jmock" % "jmock-legacy" % "2.8.3",
-  "org.scalatest" %% "scalatest" % "3.1.0-SNAP7"
+  "org.scalatest" %% "scalatest" % "3.1.0-SNAP8"
 )
 
 publishTo := {

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.2.8

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,0 +1,3 @@
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.1")
+
+addSbtPlugin("com.geirsson" % "sbt-ci-release" % "1.2.2")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,5 @@
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.1")
 
 addSbtPlugin("com.geirsson" % "sbt-ci-release" % "1.2.2")
+
+addSbtPlugin("com.typesafe.sbt" % "sbt-osgi" % "0.9.4")

--- a/src/main/scala/org/scalatestplus/jmock/AsyncJMockCycleFixture.scala
+++ b/src/main/scala/org/scalatestplus/jmock/AsyncJMockCycleFixture.scala
@@ -1,0 +1,48 @@
+/*
+  * Copyright 2001-2016 Artima, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.scalatestplus.jmock
+
+import org.scalatest._
+import org.scalatest.fixture
+
+/**
+  * Trait that will pass a new <code>JMockCycle</code> into any test that needs one.
+  *
+  * <p>
+  * This trait, which must be mixed into a <code>fixture.AsyncSuite</code>, defines the
+  * <code>Fixture</code> type to be <code>JMockCycle</code> and defines a
+  * <code>withFixture</code> method that instantiates a new <code>JMockCycle</code>
+  * and passes it to the test function.
+  * </p>
+  *
+  * @author Bill Venners
+  */
+trait AsyncJMockCycleFixture { this: fixture.AsyncTestSuite =>
+
+  /**
+    * Defines the <code>Fixture</code> type to be <code>JMockCycle</code>.
+    */
+  type FixtureParam = JMockCycle
+
+  /**
+    * Instantiates a new <code>JMockCycle</code> and passes it to the test function.
+    *
+    * @param test the test function to which to pass a new <code>JMockCycle</code>
+    */
+  def withFixture(test: OneArgAsyncTest): FutureOutcome = {
+    test(new JMockCycle)
+  }
+}

--- a/src/main/scala/org/scalatestplus/jmock/JMockCycle.scala
+++ b/src/main/scala/org/scalatestplus/jmock/JMockCycle.scala
@@ -1,0 +1,323 @@
+/*
+ * Copyright 2001-2013 Artima, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.scalatestplus.jmock
+
+import org.jmock.Mockery
+import org.jmock.lib.legacy.ClassImposteriser
+import scala.reflect.ClassTag
+
+/**
+ * Class that wraps and manages the lifecycle of a single <code>org.jmock.Mockery</code> context object,
+ * provides some basic syntax sugar for using <a href="http://www.jmock.org/" target="_blank">JMock</a>
+ * in Scala.
+ *
+ * <p>
+ * Using the JMock API directly, you first need a <code>Mockery</code> context object:
+ * </p>
+ *
+ * <pre class="stHighlight">
+ * val context = new Mockery
+ * </pre>
+ *
+ * <p>
+ * <code>JMockCycle</code> uses jMock's <code>ClassImposterizer</code> to support mocking of classes, so the following line
+ * would also be needed if you wanted that functionality as well:
+ * </p>
+ *
+ * <pre class="stHighlight">
+ * context.setImposteriser(ClassImposteriser.INSTANCE)
+ * </pre>
+ *
+ * <p>
+ * When using this class, you would instead create an instance of this class (which will create and
+ * wrap a <code>Mockery</code> object) and import its members, like this:
+ * </p>
+ *
+ * <pre class="stHighlight">
+ * val cycle = new JMockCycle
+ * import cycle._
+ * </pre>
+ *
+ * <p>
+ * Using the JMock API directly, you would create a mock object like this:
+ * </p>
+ *
+ * <pre class="stHighlight">
+ * val mockCollaborator = context.mock(classOf[Collaborator])
+ * </pre>
+ *
+ * <p>
+ * Having imported the members of an instance of this class, you can shorten that to:
+ * </p>
+ *
+ * <pre class="stHighlight">
+ * val mockCollaborator = mock[Collaborator]
+ * </pre>
+ *
+ * <p>
+ * After creating mocks, you set expectations on them, using syntax like this:
+ * </p>
+ *
+ * <pre class="stHighlight">
+ * context.checking(
+ *   new Expectations() {
+ *     oneOf (mockCollaborator).documentAdded("Document")
+ *     exactly(3).of (mockCollaborator).documentChanged("Document")
+ *    }
+ *  )
+ * </pre>
+ *
+ * <p>
+ * Having imported the members of an instance of this class, you can shorten this step to:
+ * </p>
+ *
+ * <pre class="stHighlight">
+ * expecting { e => import e._
+ *   oneOf (mockCollaborator).documentAdded("Document")
+ *   exactly(3).of (mockCollaborator).documentChanged("Document")
+ * }
+ * </pre>
+ *
+ * <p>
+ * The <code>expecting</code> method will create a new <code>Expectations</code> object, pass it into
+ * the function you provide, which sets the expectations. After the function returns, the <code>expecting</code>
+ * method will pass the <code>Expectations</code> object to the <code>checking</code>
+ * method of its internal <code>Mockery</code> context.
+ * </p>
+ *
+ * <p>
+ * The <code>expecting</code> method passes an instance of class
+ * <code>org.scalatest.mock.JMockExpectations</code> to the function you pass into
+ * <code>expectations</code>. <code>JMockExpectations</code> extends <code>org.jmock.Expectations</code> and
+ * adds several overloaded <code>withArg</code> methods. These <code>withArg</code> methods simply
+ * invoke corresponding <code>with</code> methods on themselves. Because <code>with</code> is
+ * a keyword in Scala, to invoke these directly you must surround them in back ticks, like this:
+ * </p>
+ *
+ * <pre class="stHighlight">
+ * oneOf (mockCollaborator).documentAdded(`with`("Document"))
+ * </pre>
+ *
+ * <p>
+ * By importing the members of the passed <code>JMockExpectations</code> object, you can
+ * instead call <code>withArg</code> with no back ticks needed:
+ * </p>
+ *
+ * <pre class="stHighlight">
+ * oneOf (mockCollaborator).documentAdded(withArg("Document"))
+ * </pre>
+ *
+ * <p>
+ * Once you've set expectations on the mock objects, when using the JMock API directly, you use the mock, then invoke
+ * <code>assertIsSatisfied</code> on the <code>Mockery</code> context to make sure the mock
+ * was used in accordance with the expectations you set on it. Here's how that looks:
+ * </p>
+ *
+ * <pre class="stHighlight">
+ * classUnderTest.addDocument("Document", new Array[Byte](0))
+ * classUnderTest.addDocument("Document", new Array[Byte](0))
+ * classUnderTest.addDocument("Document", new Array[Byte](0))
+ * classUnderTest.addDocument("Document", new Array[Byte](0))
+ * context.assertIsSatisfied()
+ * </pre>
+ *
+ * <p>
+ * This class enables you to use the following, more declarative syntax instead:
+ * </p>
+ *
+ * <pre class="stHighlight">
+ * whenExecuting {
+ *   classUnderTest.addDocument("Document", new Array[Byte](0))
+ *   classUnderTest.addDocument("Document", new Array[Byte](0))
+ *   classUnderTest.addDocument("Document", new Array[Byte](0))
+ *   classUnderTest.addDocument("Document", new Array[Byte](0))
+ * }
+ * </pre>
+ *
+ * <p>
+ * The <code>whenExecuting</code> method will execute the passed function, then
+ * invoke <code>assertIsSatisfied</code> on its internal <code>Mockery</code>
+ * context object.
+ * </p>
+ *
+ * <p>
+ * To summarize, here's what a typical test using <code>JMockCycle</code> looks like:
+ * </p>
+ *
+ * <pre class="stHighlight">
+ * val cycle = new JMockCycle
+ * import cycle._
+ *
+ * val mockCollaborator = mock[Collaborator]
+ *
+ * expecting { e => import e._
+ *   oneOf (mockCollaborator).documentAdded("Document")
+ *   exactly(3).of (mockCollaborator).documentChanged("Document")
+ * }
+ *
+ * whenExecuting {
+ *   classUnderTest.addDocument("Document", new Array[Byte](0))
+ *   classUnderTest.addDocument("Document", new Array[Byte](0))
+ *   classUnderTest.addDocument("Document", new Array[Byte](0))
+ *   classUnderTest.addDocument("Document", new Array[Byte](0))
+ * }
+ * </pre>
+ *
+ * <p>
+ * ScalaTest also provides a <a href="JMockCycleFixture.html"><code>JMockCycleFixture</code></a> trait, which
+ * will pass a new <code>JMockCycle</code> into each test that needs one.
+ * </p>
+ *
+ * @author Bill Venners
+ */
+final class JMockCycle {
+
+  private val context = new Mockery
+  context.setImposteriser(ClassImposteriser.INSTANCE)
+
+  /**
+   * Invokes the <code>mock</code> method on this <code>JMockCycle</code>'s internal
+   * <code>Mockery</code> context object, passing in a class instance for the
+   * specified type parameter.
+   *
+   * <p>
+   * Using the JMock API directly, you create a mock with:
+   * </p>
+   *
+   * <pre class="stHighlight">
+   * val mockCollaborator = context.mock(classOf[Collaborator])
+   * </pre>
+   *
+   * <p>
+   * Having imported the members of an instance of this class, you can shorten that to:
+   * </p>
+   *
+   * <pre class="stHighlight">
+   * val mockCollaborator = mock[Collaborator]
+   * </pre>
+   */
+  def mock[T <: AnyRef](implicit classTag: ClassTag[T]): T = {
+    context.mock(classTag.runtimeClass.asInstanceOf[Class[T]])
+  }
+
+  /**
+   * Sets expectations on mock objects.
+   *
+   * <p>
+   * After creating mocks, you set expectations on them, using syntax like this:
+   * </p>
+   *
+   * <pre class="stHighlight">
+   * context.checking(
+   *   new Expectations() {
+   *     oneOf (mockCollaborator).documentAdded("Document")
+   *     exactly(3).of (mockCollaborator).documentChanged("Document")
+   *    }
+   *  )
+   * </pre>
+   *
+   * <p>
+   * Having imported the members of an instance of this class, you can shorten this step to:
+   * </p>
+   *
+   * <pre class="stHighlight">
+   * expecting { e => import e._
+   *   oneOf (mockCollaborator).documentAdded("Document")
+   *   exactly(3).of (mockCollaborator).documentChanged("Document")
+   * }
+   * </pre>
+   *
+   * <p>
+   * The <code>expecting</code> method will create a new <code>Expectations</code> object, pass it into
+   * the function you provide, which sets the expectations. After the function returns, the <code>expecting</code>
+   * method will pass the <code>Expectations</code> object to the <code>checking</code>
+   * method of its internal <code>Mockery</code> context.
+   * </p>
+   *
+   * <p>
+   * This method passes an instance of class <code>org.scalatest.mock.JMockExpectations</code> to the
+   * passed function. <code>JMockExpectations</code> extends <code>org.jmock.Expectations</code> and
+   * adds several overloaded <code>withArg</code> methods. These <code>withArg</code> methods simply
+   * invoke corresponding <code>with</code> methods on themselves. Because <code>with</code> is
+   * a keyword in Scala, to invoke these directly you must surround them in back ticks, like this:
+   * </p>
+   *
+   * <pre class="stHighlight">
+   * oneOf (mockCollaborator).documentAdded(`with`("Document"))
+   * </pre>
+   *
+   * <p>
+   * By importing the members of the passed <code>JMockExpectations</code> object, you can
+   * instead call <code>withArg</code> with no back ticks needed:
+   * </p>
+   *
+   * <pre class="stHighlight">
+   * oneOf (mockCollaborator).documentAdded(withArg("Document"))
+   * </pre>
+   *
+   * @param fun a function that sets expectations on the passed <code>JMockExpectations</code>
+   *    object
+   */
+  def expecting(fun: JMockExpectations => Unit): Unit = {
+    val e = new JMockExpectations
+    fun(e)
+    context.checking(e)
+  }
+
+  /**
+   * Executes code using mocks with expectations set.
+   * 
+   * <p>
+   * Once you've set expectations on the mock objects, when using the JMock API directly, you use the mock, then invoke
+   * <code>assertIsSatisfied</code> on the <code>Mockery</code> context to make sure the mock
+   * was used in accordance with the expectations you set on it. Here's how that looks:
+   * </p>
+   *
+   * <pre class="stHighlight">
+   * classUnderTest.addDocument("Document", new Array[Byte](0))
+   * classUnderTest.addDocument("Document", new Array[Byte](0))
+   * classUnderTest.addDocument("Document", new Array[Byte](0))
+   * classUnderTest.addDocument("Document", new Array[Byte](0))
+   * context.assertIsSatisfied()
+   * </pre>
+   *
+   * <p>
+   * This class enables you to use the following, more declarative syntax instead:
+   * </p>
+   *
+   * <pre class="stHighlight">
+   * whenExecuting {
+   *   classUnderTest.addDocument("Document", new Array[Byte](0))
+   *   classUnderTest.addDocument("Document", new Array[Byte](0))
+   *   classUnderTest.addDocument("Document", new Array[Byte](0))
+   *   classUnderTest.addDocument("Document", new Array[Byte](0))
+   * }
+   * </pre>
+   *
+   * <p>
+   * The <code>whenExecuting</code> method will execute the passed function, then
+   * invoke <code>assertIsSatisfied</code> on its internal <code>Mockery</code>
+   * context object.
+   * </p>
+   *
+   * @param fun the code to execute under previously set expectations
+   * @throws org.mock.ExpectationError if an expectation is not met
+   */
+  def whenExecuting(fun: => Unit): Unit = {
+    fun
+    context.assertIsSatisfied()
+  }
+}

--- a/src/main/scala/org/scalatestplus/jmock/JMockCycleFixture.scala
+++ b/src/main/scala/org/scalatestplus/jmock/JMockCycleFixture.scala
@@ -1,0 +1,48 @@
+/*
+  * Copyright 2001-2013 Artima, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.scalatestplus.jmock
+
+import org.scalatest._
+import org.scalatest.fixture
+
+/**
+ * Trait that will pass a new <code>JMockCycle</code> into any test that needs one.
+ *
+ * <p>
+ * This trait, which must be mixed into a <code>fixture.Suite</code>, defines the
+ * <code>Fixture</code> type to be <code>JMockCycle</code> and defines a
+ * <code>withFixture</code> method that instantiates a new <code>JMockCycle</code>
+ * and passes it to the test function.
+ * </p>
+ *
+ * @author Bill Venners
+ */
+trait JMockCycleFixture { this: fixture.TestSuite =>
+
+  /**
+   * Defines the <code>Fixture</code> type to be <code>JMockCycle</code>.
+   */
+  type FixtureParam = JMockCycle
+
+  /**
+   * Instantiates a new <code>JMockCycle</code> and passes it to the test function.
+   *
+   * @param test the test function to which to pass a new <code>JMockCycle</code>
+   */
+  def withFixture(test: OneArgTest): Outcome = {
+    test(new JMockCycle)
+  }
+}

--- a/src/main/scala/org/scalatestplus/jmock/JMockExpectations.scala
+++ b/src/main/scala/org/scalatestplus/jmock/JMockExpectations.scala
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2001-2013 Artima, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.scalatestplus.jmock
+
+import org.jmock.Expectations
+import org.hamcrest.Matcher
+
+/**
+ * Subclass of <code>org.jmock.Expectations</code> that provides <code>withArg</code>
+ * alternatives to the <code>with</code> methods defined in its superclass.
+ *
+ * <p>
+ * <code>JMockCycle</code>'s <code>expecting</code> method of passes an instance of this class
+ * to the function passed into <code>expectations</code>. Because <code>JMockExpectations</code>
+ * extends <code>org.jmock.Expectations</code>, all of the <code>Expectations</code> methods are
+ * available to be invoked on instances of this class, in addition to
+ * several overloaded <code>withArg</code> methods defined in this class. These <code>withArg</code> methods simply
+ * invoke corresponding <code>with</code> methods on <code>this</code>. Because <code>with</code> is
+ * a keyword in Scala, to invoke these directly you must surround them in back ticks, like this:
+ * </p>
+ *
+ * <pre class="stHighlight">
+ * oneOf (mockCollaborator).documentAdded(`with`("Document"))
+ * </pre>
+ *
+ * <p>
+ * By importing the members of the <code>JMockExpectations</code> object passed to
+ * a <code>JMockCycle</code>'s <code>executing</code> method, you can
+ * instead call <code>withArg</code> with no back ticks needed:
+ * </p>
+ *
+ * <pre class="stHighlight">
+ * oneOf (mockCollaborator).documentAdded(withArg("Document"))
+ * </pre>
+ *
+ * @author Bill Venners
+ */
+final class JMockExpectations extends Expectations {
+
+  /**
+   * Invokes <code>with</code> on this instance, passing in the passed value.
+   */
+  def withArg[T](value: T): T = `with`(value)
+
+  /**
+   * Invokes <code>with</code> on this instance, passing in the passed value.
+   */
+  def withArg(value: Int): Int = `with`(value)
+
+  /**
+   * Invokes <code>with</code> on this instance, passing in the passed value.
+   */
+  def withArg(value: Short): Short = `with`(value)
+
+  /**
+   * Invokes <code>with</code> on this instance, passing in the passed value.
+   */
+  def withArg(value: Byte): Byte = `with`(value)
+
+  /**
+   * Invokes <code>with</code> on this instance, passing in the passed value.
+   */
+  def withArg(value: Long): Long = `with`(value)
+
+  /**
+   * Invokes <code>with</code> on this instance, passing in the passed value.
+   */
+  def withArg(value: Boolean): Boolean = `with`(value)
+
+  /**
+   * Invokes <code>with</code> on this instance, passing in the passed value.
+   */
+  def withArg(value: Float): Float = `with`(value)
+
+  /**
+   * Invokes <code>with</code> on this instance, passing in the passed value.
+   */
+  def withArg(value: Double): Double = `with`(value)
+
+  /**
+   * Invokes <code>with</code> on this instance, passing in the passed value.
+   */
+  def withArg(value: Char): Char = `with`(value)
+
+  /**
+   * Invokes <code>with</code> on this instance, passing in the passed matcher.
+   */
+  def withArg[T](matcher: Matcher[T]): T = `with`(matcher)
+
+  /**
+   * Invokes <code>with</code> on this instance, passing in the passed matcher.
+   */
+  def withArg(matcher: Matcher[Int]): Int = `with`(matcher)
+
+  /**
+   * Invokes <code>with</code> on this instance, passing in the passed matcher.
+   */
+  def withArg(matcher: Matcher[Short]): Short = `with`(matcher)
+
+  /**
+   * Invokes <code>with</code> on this instance, passing in the passed matcher.
+   */
+  def withArg(matcher: Matcher[Byte]): Byte = `with`(matcher)
+
+  /**
+   * Invokes <code>with</code> on this instance, passing in the passed matcher.
+   */
+  def withArg(matcher: Matcher[Long]): Long = `with`(matcher)
+
+  /**
+   * Invokes <code>with</code> on this instance, passing in the passed matcher.
+   */
+  def withArg(matcher: Matcher[Boolean]): Boolean = `with`(matcher)
+
+  /**
+   * Invokes <code>with</code> on this instance, passing in the passed matcher.
+   */
+  def withArg(matcher: Matcher[Float]): Float = `with`(matcher)
+
+  /**
+   * Invokes <code>with</code> on this instance, passing in the passed matcher.
+   */
+  def withArg(matcher: Matcher[Double]): Double = `with`(matcher)
+
+  /**
+   * Invokes <code>with</code> on this instance, passing in the passed matcher.
+   */
+  def withArg(matcher: Matcher[Char]): Char = `with`(matcher)
+}

--- a/src/test/scala/org/scalatestplus/jmock/AsyncJMockCycleSpec.scala
+++ b/src/test/scala/org/scalatestplus/jmock/AsyncJMockCycleSpec.scala
@@ -1,0 +1,211 @@
+/*
+ * Copyright 2001-2013 Artima, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.scalatestplus.jmock
+
+import org.scalatest._
+import org.jmock.AbstractExpectations.{equal => thatEquals}
+import org.scalatest.fixture
+
+
+class AsyncJMockCycleSpec extends FlatSpec with Matchers {
+
+  "The AsyncJMockCycle trait" should "work with multiple mocks" in {
+
+    val a = new fixture.AsyncFunSuite with AsyncJMockCycleFixture {
+      test("test that should fail") { cycle =>
+        import cycle._
+        trait OneFish {
+          def eat(food: String): Unit = ()
+        }
+        trait TwoFish {
+          def eat(food: String): Unit = ()
+        }
+        val oneFishMock = mock[OneFish]
+        val twoFishMock = mock[TwoFish]
+
+        expecting { e => import e.{oneOf => OneOf}
+
+          OneOf (oneFishMock).eat("red fish")
+          OneOf (twoFishMock).eat("blue fish")
+        }
+
+        whenExecuting {
+          oneFishMock.eat("red fish")
+          twoFishMock.eat("green fish")
+        }
+
+        succeed
+      }
+
+      test("test that should succeed") { cycle =>
+        import cycle._
+        trait OneFish {
+          def eat(food: String): Unit = ()
+        }
+        trait TwoFish {
+          def eat(food: String): Unit = ()
+        }
+        val oneFishMock = mock[OneFish]
+        val twoFishMock = mock[TwoFish]
+
+        expecting { e => import e.{oneOf => OneOf}
+
+          OneOf (oneFishMock).eat("red fish")
+          OneOf (twoFishMock).eat("blue fish")
+        }
+
+        whenExecuting {
+          oneFishMock.eat("red fish")
+          twoFishMock.eat("blue fish")
+        }
+
+        succeed
+      }
+
+      test("test that should succeed with class") { cycle =>
+        import cycle._
+        class OneFish {
+          def eat(food: String): Unit = ()
+        }
+        class TwoFish {
+          def eat(food: String): Unit = ()
+        }
+        val oneFishMock = mock[OneFish]
+        val twoFishMock = mock[TwoFish]
+
+        expecting { e => import e.{oneOf => OneOf}
+
+          OneOf (oneFishMock).eat("red fish")
+          OneOf (twoFishMock).eat("blue fish")
+        }
+
+        whenExecuting {
+          oneFishMock.eat("red fish")
+          twoFishMock.eat("blue fish")
+        }
+
+        succeed
+      }
+    }
+    val rep = new EventRecordingReporter
+    a.run(None, Args(rep))
+    val tf = rep.testFailedEventsReceived
+    tf.size should === (1)
+    val ts = rep.testSucceededEventsReceived
+    ts.size should === (2)
+  }
+
+  it should "provide sugar for invoking with methods that take matchers" in {
+    val a = new fixture.AsyncFunSuite with AsyncJMockCycleFixture {
+      test("test that should succeed") { cycle =>
+        import cycle._
+        trait OneFish {
+          def doString(food: String): Unit = ()
+          def doInt(food: Int): Unit = ()
+          def doShort(food: Short): Unit = ()
+          def doByte(food: Byte): Unit = ()
+          def doLong(food: Long): Unit = ()
+          def doBoolean(food: Boolean): Unit = ()
+          def doFloat(food: Float): Unit = ()
+          def doDouble(food: Double): Unit = ()
+          def doChar(food: Char): Unit = ()
+        }
+        val oneFishMock = mock[OneFish]
+
+        expecting { e => import e.{oneOf => OneOf, withArg}
+
+          OneOf (oneFishMock).doString(withArg(thatEquals("red fish")))
+          OneOf (oneFishMock).doInt(withArg(thatEquals(5)))
+          OneOf (oneFishMock).doShort(withArg(thatEquals(5.asInstanceOf[Short])))
+          OneOf (oneFishMock).doByte(withArg(thatEquals(5.asInstanceOf[Byte])))
+          OneOf (oneFishMock).doLong(withArg(thatEquals(5L)))
+          OneOf (oneFishMock).doBoolean(withArg(thatEquals(true)))
+          OneOf (oneFishMock).doFloat(withArg(thatEquals(5.0f)))
+          OneOf (oneFishMock).doDouble(withArg(thatEquals(5.0d)))
+          OneOf (oneFishMock).doChar(withArg(thatEquals('5')))
+        }
+
+        whenExecuting {
+          oneFishMock.doString("red fish")
+          oneFishMock.doInt(5)
+          oneFishMock.doShort(5)
+          oneFishMock.doByte(5)
+          oneFishMock.doLong(5L)
+          oneFishMock.doBoolean(true)
+          oneFishMock.doFloat(5.0f)
+          oneFishMock.doDouble(5.0d)
+          oneFishMock.doChar('5')
+        }
+
+        succeed
+      }
+    }
+    val rep = new EventRecordingReporter
+    a.run(None, Args(rep))
+    val ts = rep.testSucceededEventsReceived
+    ts.size should === (1)
+  }
+
+  it should "provide sugar for invoking with methods that take non-matcher values" in {
+    val a = new fixture.AsyncFunSuite with AsyncJMockCycleFixture {
+      test("test that should succeed") { cycle =>
+        import cycle._
+        trait OneFish {
+          def doString(food: String): Unit = ()
+          def doInt(food: Int): Unit = ()
+          def doShort(food: Short): Unit = ()
+          def doByte(food: Byte): Unit = ()
+          def doLong(food: Long): Unit = ()
+          def doBoolean(food: Boolean): Unit = ()
+          def doFloat(food: Float): Unit = ()
+          def doDouble(food: Double): Unit = ()
+          def doChar(food: Char): Unit = ()
+        }
+        val oneFishMock = mock[OneFish]
+
+        expecting { e => import e.{oneOf => OneOf, withArg}
+          OneOf (oneFishMock).doString(withArg("red fish"))
+          OneOf (oneFishMock).doInt(withArg(5))
+          OneOf (oneFishMock).doShort(withArg(5.asInstanceOf[Short]))
+          OneOf (oneFishMock).doByte(withArg(5.asInstanceOf[Byte]))
+          OneOf (oneFishMock).doLong(withArg(5L))
+          OneOf (oneFishMock).doBoolean(withArg(true))
+          OneOf (oneFishMock).doFloat(withArg(5.0f))
+          OneOf (oneFishMock).doDouble(withArg(5.0d))
+          OneOf (oneFishMock).doChar(withArg('5'))
+        }
+
+        whenExecuting {
+          oneFishMock.doString("red fish")
+          oneFishMock.doInt(5)
+          oneFishMock.doShort(5)
+          oneFishMock.doByte(5)
+          oneFishMock.doLong(5L)
+          oneFishMock.doBoolean(true)
+          oneFishMock.doFloat(5.0f)
+          oneFishMock.doDouble(5.0d)
+          oneFishMock.doChar('5')
+        }
+
+        succeed
+      }
+    }
+    val rep = new EventRecordingReporter
+    a.run(None, Args(rep))
+    val ts = rep.testSucceededEventsReceived
+    ts.size should === (1)
+  }
+}

--- a/src/test/scala/org/scalatestplus/jmock/EventRecorderReporter.scala
+++ b/src/test/scala/org/scalatestplus/jmock/EventRecorderReporter.scala
@@ -1,0 +1,192 @@
+package org.scalatestplus.jmock
+
+import org.scalatest.{Args, Reporter, Suite}
+import org.scalatest.events._
+
+class EventRecordingReporter extends Reporter {
+  private var eventList: List[Event] = List()
+  def eventsReceived = synchronized { eventList.reverse }
+  def testSucceededEventsReceived: List[TestSucceeded] = {
+    synchronized {
+      eventsReceived filter {
+        case event: TestSucceeded => true
+        case _ => false
+      } map {
+        case event: TestSucceeded => event
+        case _ => throw new RuntimeException("should never happen")
+      }
+    }
+  }
+  def testStartingEventsReceived: List[TestStarting] = {
+    synchronized {
+      eventsReceived filter {
+        case event: TestStarting => true
+        case _ => false
+      } map {
+        case event: TestStarting => event
+        case _ => throw new RuntimeException("should never happen")
+      }
+    }
+  }
+  // Why doesn't this work:
+  // for (event: TestSucceeded <- eventsReceived) yield event
+  def infoProvidedEventsReceived: List[InfoProvided] = {
+    synchronized {
+      eventsReceived filter {
+        case event: InfoProvided => true
+        case _ => false
+      } map {
+        case event: InfoProvided => event
+        case _ => throw new RuntimeException("should never happen")
+      }
+    }
+  }
+  def noteProvidedEventsReceived: List[NoteProvided] = {
+    synchronized {
+      eventsReceived filter {
+        case event: NoteProvided => true
+        case _ => false
+      } map {
+        case event: NoteProvided => event
+        case _ => throw new RuntimeException("should never happen")
+      }
+    }
+  }
+  def alertProvidedEventsReceived: List[AlertProvided] = {
+    synchronized {
+      eventsReceived filter {
+        case event: AlertProvided => true
+        case _ => false
+      } map {
+        case event: AlertProvided => event
+        case _ => throw new RuntimeException("should never happen")
+      }
+    }
+  }
+  def markupProvidedEventsReceived: List[MarkupProvided] = {
+    synchronized {
+      eventsReceived filter {
+        case event: MarkupProvided => true
+        case _ => false
+      } map {
+        case event: MarkupProvided => event
+        case _ => throw new RuntimeException("should never happen")
+      }
+    }
+  }
+  def scopeOpenedEventsReceived: List[ScopeOpened] = {
+    synchronized {
+      eventsReceived filter {
+        case event: ScopeOpened => true
+        case _ => false
+      } map {
+        case event: ScopeOpened => event
+        case _ => throw new RuntimeException("should never happen")
+      }
+    }
+  }
+  def scopeClosedEventsReceived: List[ScopeClosed] = {
+    synchronized {
+      eventsReceived filter {
+        case event: ScopeClosed => true
+        case _ => false
+      } map {
+        case event: ScopeClosed => event
+        case _ => throw new RuntimeException("should never happen")
+      }
+    }
+  }
+  def scopePendingEventsReceived: List[ScopePending] = {
+    synchronized {
+      eventsReceived filter {
+        case event: ScopePending => true
+        case _ => false
+      } map {
+        case event: ScopePending => event
+        case _ => throw new RuntimeException("should never happen")
+      }
+    }
+  }
+  def testPendingEventsReceived: List[TestPending] = {
+    synchronized {
+      eventsReceived filter {
+        case event: TestPending => true
+        case _ => false
+      } map {
+        case event: TestPending => event
+        case _ => throw new RuntimeException("should never happen")
+      }
+    }
+  }
+  def testCanceledEventsReceived: List[TestCanceled] = {
+    synchronized {
+      eventsReceived filter {
+        case event: TestCanceled => true
+        case _ => false
+      } map {
+        case event: TestCanceled => event
+        case _ => throw new RuntimeException("should never happen")
+      }
+    }
+  }
+  def testFailedEventsReceived: List[TestFailed] = {
+    synchronized {
+      eventsReceived filter {
+        case event: TestFailed => true
+        case _ => false
+      } map {
+        case event: TestFailed => event
+        case _ => throw new RuntimeException("should never happen")
+      }
+    }
+  }
+  def testIgnoredEventsReceived: List[TestIgnored] = {
+    synchronized {
+      eventsReceived filter {
+        case event: TestIgnored => true
+        case _ => false
+      } map {
+        case event: TestIgnored => event
+        case _ => throw new RuntimeException("should never happen")
+      }
+    }
+  }
+  def suiteStartingEventsReceived: List[SuiteStarting] = {
+    synchronized {
+      eventsReceived filter {
+        case event: SuiteStarting => true
+        case _ => false
+      } map {
+        case event: SuiteStarting => event
+        case _ => throw new RuntimeException("should never happen")
+      }
+    }
+  }
+  def suiteCompletedEventsReceived: List[SuiteCompleted] = {
+    synchronized {
+      eventsReceived filter {
+        case event: SuiteCompleted => true
+        case _ => false
+      } map {
+        case event: SuiteCompleted => event
+        case _ => throw new RuntimeException("should never happen")
+      }
+    }
+  }
+  def suiteAbortedEventsReceived: List[SuiteAborted] = {
+    synchronized {
+      eventsReceived filter {
+        case event: SuiteAborted => true
+        case _ => false
+      } map {
+        case event: SuiteAborted => event
+        case _ => throw new RuntimeException("should never happen")
+      }
+    }
+  }
+  def apply(event: Event): Unit = {
+    synchronized {
+      eventList ::= event
+    }
+  }
+}

--- a/src/test/scala/org/scalatestplus/jmock/JMockCycleSpec.scala
+++ b/src/test/scala/org/scalatestplus/jmock/JMockCycleSpec.scala
@@ -1,0 +1,200 @@
+/*
+ * Copyright 2001-2013 Artima, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.scalatestplus.jmock
+
+import org.scalatest._
+import org.scalatest.fixture
+import org.jmock.AbstractExpectations.{equal => thatEquals}
+
+class JMockCycleSpec extends FlatSpec with Matchers {
+
+  "The JMockCycle trait" should "work with multiple mocks" in {
+
+    val a = new fixture.Spec with JMockCycleFixture {
+      def `test that should fail`(cycle: JMockCycle): Unit = {
+        import cycle._
+        trait OneFish {
+          def eat(food: String): Unit = ()
+        }
+        trait TwoFish {
+          def eat(food: String): Unit = ()
+        }
+        val oneFishMock = mock[OneFish]
+        val twoFishMock = mock[TwoFish]
+
+        expecting { e => import e.{oneOf => OneOf}
+
+          OneOf (oneFishMock).eat("red fish")
+          OneOf (twoFishMock).eat("blue fish")
+        }
+
+        whenExecuting {
+          oneFishMock.eat("red fish")
+          twoFishMock.eat("green fish")
+        }
+      }
+
+      def `test that should succeed`(cycle: JMockCycle): Unit = {
+        import cycle._
+        trait OneFish {
+          def eat(food: String): Unit = ()
+        }
+        trait TwoFish {
+          def eat(food: String): Unit = ()
+        }
+        val oneFishMock = mock[OneFish]
+        val twoFishMock = mock[TwoFish]
+
+        expecting { e => import e.{oneOf => OneOf}
+
+          OneOf (oneFishMock).eat("red fish")
+          OneOf (twoFishMock).eat("blue fish")
+        }
+
+        whenExecuting {
+          oneFishMock.eat("red fish")
+          twoFishMock.eat("blue fish")
+        }
+      }
+
+      def `test that should succeed with class`(cycle: JMockCycle): Unit = {
+        import cycle._
+        class OneFish {
+          def eat(food: String): Unit = ()
+        }
+        class TwoFish {
+          def eat(food: String): Unit = ()
+        }
+        val oneFishMock = mock[OneFish]
+        val twoFishMock = mock[TwoFish]
+
+        expecting { e => import e.{oneOf => OneOf}
+
+          OneOf (oneFishMock).eat("red fish")
+          OneOf (twoFishMock).eat("blue fish")
+        }
+
+        whenExecuting {
+          oneFishMock.eat("red fish")
+          twoFishMock.eat("blue fish")
+        }
+      }
+    }
+    val rep = new EventRecordingReporter
+    a.run(None, Args(rep))
+    val tf = rep.testFailedEventsReceived
+    tf.size should === (1)
+    val ts = rep.testSucceededEventsReceived
+    ts.size should === (2)
+  }
+
+  it should "provide sugar for invoking with methods that take matchers" in {
+    val a = new fixture.Spec with JMockCycleFixture {
+      def `test that should succeed`(cycle: JMockCycle): Unit = {
+        import cycle._
+        trait OneFish {
+          def doString(food: String): Unit = ()
+          def doInt(food: Int): Unit = ()
+          def doShort(food: Short): Unit = ()
+          def doByte(food: Byte): Unit = ()
+          def doLong(food: Long): Unit = ()
+          def doBoolean(food: Boolean): Unit = ()
+          def doFloat(food: Float): Unit = ()
+          def doDouble(food: Double): Unit = ()
+          def doChar(food: Char): Unit = ()
+        }
+        val oneFishMock = mock[OneFish]
+
+        expecting { e => import e.{oneOf => OneOf, withArg}
+
+          OneOf (oneFishMock).doString(withArg(thatEquals("red fish")))
+          OneOf (oneFishMock).doInt(withArg(thatEquals(5)))
+          OneOf (oneFishMock).doShort(withArg(thatEquals(5.asInstanceOf[Short])))
+          OneOf (oneFishMock).doByte(withArg(thatEquals(5.asInstanceOf[Byte])))
+          OneOf (oneFishMock).doLong(withArg(thatEquals(5L)))
+          OneOf (oneFishMock).doBoolean(withArg(thatEquals(true)))
+          OneOf (oneFishMock).doFloat(withArg(thatEquals(5.0f)))
+          OneOf (oneFishMock).doDouble(withArg(thatEquals(5.0d)))
+          OneOf (oneFishMock).doChar(withArg(thatEquals('5')))
+        }
+
+        whenExecuting {
+          oneFishMock.doString("red fish")
+          oneFishMock.doInt(5)
+          oneFishMock.doShort(5)
+          oneFishMock.doByte(5)
+          oneFishMock.doLong(5L)
+          oneFishMock.doBoolean(true)
+          oneFishMock.doFloat(5.0f)
+          oneFishMock.doDouble(5.0d)
+          oneFishMock.doChar('5')
+        }
+      }
+    }
+    val rep = new EventRecordingReporter
+    a.run(None, Args(rep))
+    val ts = rep.testSucceededEventsReceived
+    ts.size should === (1)
+  }
+
+  it should "provide sugar for invoking with methods that take non-matcher values" in {
+    val a = new fixture.Spec with JMockCycleFixture {
+      def `test that should succeed`(cycle: JMockCycle): Unit = {
+        import cycle._
+        trait OneFish {
+          def doString(food: String): Unit = ()
+          def doInt(food: Int): Unit = ()
+          def doShort(food: Short): Unit = ()
+          def doByte(food: Byte): Unit = ()
+          def doLong(food: Long): Unit = ()
+          def doBoolean(food: Boolean): Unit = ()
+          def doFloat(food: Float): Unit = ()
+          def doDouble(food: Double): Unit = ()
+          def doChar(food: Char): Unit = ()
+        }
+        val oneFishMock = mock[OneFish]
+
+        expecting { e => import e.{oneOf => OneOf, withArg}
+          OneOf (oneFishMock).doString(withArg("red fish"))
+          OneOf (oneFishMock).doInt(withArg(5))
+          OneOf (oneFishMock).doShort(withArg(5.asInstanceOf[Short]))
+          OneOf (oneFishMock).doByte(withArg(5.asInstanceOf[Byte]))
+          OneOf (oneFishMock).doLong(withArg(5L))
+          OneOf (oneFishMock).doBoolean(withArg(true))
+          OneOf (oneFishMock).doFloat(withArg(5.0f))
+          OneOf (oneFishMock).doDouble(withArg(5.0d))
+          OneOf (oneFishMock).doChar(withArg('5'))
+        }
+
+        whenExecuting {
+          oneFishMock.doString("red fish")
+          oneFishMock.doInt(5)
+          oneFishMock.doShort(5)
+          oneFishMock.doByte(5)
+          oneFishMock.doLong(5L)
+          oneFishMock.doBoolean(true)
+          oneFishMock.doFloat(5.0f)
+          oneFishMock.doDouble(5.0d)
+          oneFishMock.doChar('5')
+        }
+      }
+    }
+    val rep = new EventRecordingReporter
+    a.run(None, Args(rep))
+    val ts = rep.testSucceededEventsReceived
+    ts.size should === (1)
+  }
+}

--- a/src/test/scala/org/scalatestplus/jmock/SuiteExpectations.scala
+++ b/src/test/scala/org/scalatestplus/jmock/SuiteExpectations.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2001-2013 Artima, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.scalatestplus.jmock
+
+import org.scalatest._
+import org.jmock.Expectations
+import org.hamcrest.core.IsAnything
+import org.scalatest.events._
+
+trait SuiteExpectations {
+
+  def expectSingleTestToPass(expectations: Expectations, reporter: Reporter): Unit = expectNTestsToPass(expectations, 1, reporter)
+  def expectSingleTestToFail(expectations: Expectations, reporter: Reporter): Unit = expectNTestsToFail(expectations, 1, reporter)
+  
+  def expectNTestsToPass(expectations: Expectations, n: Int, reporter: Reporter): Unit = {
+    expectNTestsToRun(expectations, n, reporter) { 
+      expectations.one(reporter).apply(expectations.`with`(new IsAnything[TestSucceeded]))
+    }
+  }
+  
+  def expectNTestsToFail(expectations: Expectations, n: Int, reporter: Reporter): Unit = {
+    expectNTestsToRun(expectations, n, reporter) { 
+      expectations.one(reporter).apply(expectations.`with`(new IsAnything[TestFailed]))
+    }
+  }
+
+  def expectNTestsToRun(expectations: Expectations, n: Int, reporter: Reporter)(f: => Unit): Unit = {
+    expectations.never(reporter).apply(expectations.`with`(new IsAnything[SuiteStarting]))
+    for( i <- 1 to n ){
+      expectations.one(reporter).apply(expectations.`with`(new IsAnything[TestStarting]))
+      f
+    }
+    expectations.never(reporter).apply(expectations.`with`(new IsAnything[SuiteCompleted]))
+  }
+}
+

--- a/src/test/scala/org/scalatestplus/jmock/TestReporter.scala
+++ b/src/test/scala/org/scalatestplus/jmock/TestReporter.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2001-2013 Artima, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.scalatestplus.jmock;
+
+import org.scalatest._
+import org.scalatest.events._
+
+class TestReporter extends Reporter {
+
+  var lastEvent: Option[Event] = None
+
+  var successCount = 0
+  var failureCount = 0
+  
+  var ignoreCount = 0
+  
+  // def errorMessage = event.get.throwable.get.getMessage
+
+  def apply(event: Event): Unit = {
+    event match {
+      case event: TestIgnored =>
+        ignoreCount = ignoreCount + 1 
+        lastEvent = Some(event)
+      case event: TestSucceeded =>
+        successCount = successCount + 1 
+        lastEvent = Some(event)
+      case event: TestFailed =>
+        failureCount = failureCount + 1 
+        lastEvent = Some(event)
+      case _ =>
+    }
+  }
+}


### PR DESCRIPTION
Moving over jmock integration code from current 3.1.x branch in ScalaTest.